### PR TITLE
DNA-456 - Moved woocomerce email checkbox

### DIFF
--- a/core/App.php
+++ b/core/App.php
@@ -228,7 +228,26 @@ class App
      * Place this in your Functions.php file
      **/
     public static function woocommerce_subscription_box_before() {
-        echo "<br style='clear:both'>";
+        $legend = Helper::getOption('subscribe_text');
+        $autoSubscribe = Helper::getOption('automatic_subscription');
+
+        $isChecked = '';
+        if (!empty($autoSubscribe) && $autoSubscribe ){
+            $isChecked = 'checked="checked"';
+        }
+        if (empty($legend)){
+            $legend = 'Subscribe to our newsletter';
+        }
+
+        $html = '';
+        $html .= '<input id="subscriptionNonce" type="hidden" name="subscription_nonce" value="'.wp_create_nonce('app_nonce').'">';
+        $html .= '<label for="cmw_register_email" style="margin-bottom: 7px;">';
+        $html .= '<input id="cmw_register_email" name="cmw_register_email" style="margin-right: 7px;" value="on" '.$isChecked.' type="checkbox">'.$legend.'</label>';
+        $subscriptionBox = \core\Helper::getOption('toggle_subscription_box');
+
+        if ($subscriptionBox){
+            echo $html;
+        }
     }
 
     public static function checkout_process($orderId){
@@ -314,27 +333,7 @@ class App
         }
     }
     public static function woocommerce_subscription_box(){
-
-        $legend = Helper::getOption('subscribe_text');
-        $autoSubscribe = Helper::getOption('automatic_subscription');
-
-        $isChecked = '';
-        if (!empty($autoSubscribe) && $autoSubscribe ){
-            $isChecked = 'checked="checked"';
-        }
-        if (empty($legend)){
-            $legend = 'Subscribe to our newsletter';
-        }
-
-        $html = '';
-        $html .= '<input id="subscriptionNonce" type="hidden" name="subscription_nonce" value="'.wp_create_nonce('app_nonce').'">';
-        $html .= '<label for="cmw_register_email">';
-        $html .= '<input id="cmw_register_email" name="cmw_register_email" value="on" '.$isChecked.' type="checkbox">'.$legend.'</label>';
-        $subscriptionBox = \core\Helper::getOption('toggle_subscription_box');
-
-        if ($subscriptionBox){
-            echo $html;
-        }
+        echo '<br></br>';
     }
     /**
      * @return bool true if connected false otherwise


### PR DESCRIPTION
### Description
Moved the "subscribe to our newsletter" checkbox above the "Place Order" button during woo commerce checkout, as it's more intuitive. Also fixed some styling issues.

#### Before
![image](https://user-images.githubusercontent.com/34179563/77037693-fbcb3200-6a05-11ea-9cdb-da417513895d.png)

#### After
![image](https://user-images.githubusercontent.com/34179563/77037624-dc340980-6a05-11ea-91de-7de0a3c63fbf.png)
