### PR TITLE
EL-865b -- Remove the ability to use Confirmed opt-in list 

### DIFF
--- a/core/Ajax.php
+++ b/core/Ajax.php
@@ -201,9 +201,8 @@ abstract class Ajax
             self::remove_notice('connected_list_notice');
 
             if (array_key_exists('new_list_name', $params ) && !empty($params['new_list_name'])){
-                $optIn = ($params['new_list_type'] == 2) ? true : false;
                 $newListName = $params['new_list_name'];
-                $newListId = App::$CampaignMonitor->create_list($params['ClientID'], $newListName, $optIn);
+                $newListId = App::$CampaignMonitor->create_list($params['ClientID'], $newListName, false);
                 $params['ListID'] = $newListId;
             }
 
@@ -439,8 +438,6 @@ abstract class Ajax
             $clientId = $params['ClientID'];
             $lists = App::$CampaignMonitor->get_client_list($clientId);
 
-
-
             $html = '';
             if ($lists) {
                 $html = '<select id="lists"  class="ajax-call list client-list dropdown-select ">';
@@ -453,26 +450,42 @@ abstract class Ajax
                 $html .= 'Create new list';
                 $html .= '</option>';
                 $html .= '<option class="ajax-call" disabled >';
-                $html .= '---';
+                $html .= '--- Single opt-in --- suitable for this plugin';
                 $html .= '</option>';
                 $isSelected = false;
+                $hasConfirmedOptInList = false;
+                $htmlConfirmedOptIn = '';
                 foreach ($lists as $list) {
                     $id = $list->ListID;
-
+                    
                     $viewClientListUrl = http_build_query((array)$list);
-                    $fields = App::$CampaignMonitor->get_stats($id);
+                    $listDetails = App::$CampaignMonitor->get_list_details($id);
                     $selected = '';
 
                     if ($id == $selectedList){
                         $selected = 'selected="selected"';
                         $isSelected = true;
                     }
+                        
+                    if (!$listDetails->ConfirmedOptIn) {
+                        $html .= '<option '.$selected .' value="'.$clientId.'" data-id="'.$id.'"  data-url="' . self::$actionUrl . '&' . $viewClientListUrl . '&ClientID=' . $clientId . '&action=get_list_settings">';
+                        $html .= Util::htmlDecodeEncode($list->Name);
+                        $html .= '</option>';
+                    }
+                    else {
+                        $hasConfirmedOptInList = true;
+                        $htmlConfirmedOptIn .= '<option '.$selected .' disabled value="'.$clientId.'" data-id="'.$id.'"  data-url="' . self::$actionUrl . '&' . $viewClientListUrl . '&ClientID=' . $clientId . '&action=get_list_settings">';
+                        $htmlConfirmedOptIn .= Util::htmlDecodeEncode($list->Name);
+                        $htmlConfirmedOptIn .= '</option>';
+                    }
+                }
 
-
-                    $html .= '<option '.$selected .' value="'.$clientId.'" data-id="'.$id.'"  data-url="' . self::$actionUrl . '&' . $viewClientListUrl . '&ClientID=' . $clientId . '&action=get_list_settings">';
-                    $html .= Util::htmlDecodeEncode($list->Name);
+                if ($hasConfirmedOptInList) {
+                    $html .= '<option class="ajax-call" disabled >';
+                    $html .= '--- Confirmed opt-in --- not suitable for this plugin';
                     $html .= '</option>';
 
+                    $html .= $htmlConfirmedOptIn;
                 }
 
                 $html .= '</select>';

--- a/core/Ajax.php
+++ b/core/Ajax.php
@@ -462,12 +462,12 @@ abstract class Ajax
                     $listDetails = App::$CampaignMonitor->get_list_details($id);
                     $selected = '';
 
-                    if ($id == $selectedList){
-                        $selected = 'selected="selected"';
-                        $isSelected = true;
-                    }
-                        
                     if (!$listDetails->ConfirmedOptIn) {
+                        if ($id == $selectedList){
+                            $selected = 'selected="selected"';
+                            $isSelected = true;
+                        }
+   
                         $html .= '<option '.$selected .' value="'.$clientId.'" data-id="'.$id.'"  data-url="' . self::$actionUrl . '&' . $viewClientListUrl . '&ClientID=' . $clientId . '&action=get_list_settings">';
                         $html .= Util::htmlDecodeEncode($list->Name);
                         $html .= '</option>';

--- a/core/App.php
+++ b/core/App.php
@@ -274,56 +274,61 @@ class App
             }
 
             if (array_key_exists('cmw_register_email', $_POST)){
-                if (!empty($newCustomer->data)){
-                    $listId = Settings::get('default_list');
-                    $mappedFields = Map::get();
-                    $details = current($newCustomer->data);
-
-                    $autoSubscribe = Helper::getOption('automatic_subscription');
-                    if (!empty($autoSubscribe) && $autoSubscribe ){
-                        if (!empty($email)){
-                            Subscribers::add($email);
-                            $isSubscribe = true;
-                        }
-                    }
-
-                    if (!empty($email) || isset($address['email'])){
-                        if (isset($address['email']) && !empty($address['email'])){
-                            $emailToEnroll = $address['email'];
-                        } else if (!empty($email)){
-                            $emailToEnroll = $email;
-                        }
-
-                        $alreadyEnroll = Subscribers::get($emailToEnroll);
-                        if (!empty($alreadyEnroll)){
-                            $isSubscribe = true;
-                        }
-                    }
-
-                    $expiry = Settings::get('expiry');
-                    $auth = array(
-                        'access_token' => Settings::get('access_token'),
-                        'refresh_token' => Settings::get('refresh_token')
-                    );
-                    if ($expiry !== null && ($expiry - time() <  (60*60*24)))
-                    {
-                        list($new_access_token, $new_expires_in, $new_refresh_token) = self::$CampaignMonitor->refresh_token($auth);
-
-                        Settings::add('access_token',$new_access_token);
-                        Settings::add('refresh_token',$new_refresh_token);
-                        Settings::add('expiry',$new_expires_in + time());
-                        $auth = array(
-                            'access_token' => $new_access_token,
-                            'refresh_token' => $new_refresh_token
-                        );
-                    }
-
-                    $userToExport = Customer::format($details, $mappedFields, $isSubscribe);
-                    $userToExport = (array)$userToExport;
-                    $result = self::$CampaignMonitor->add_subscriber($listId, $userToExport, $auth);
-                    Log::write($result);
+                if (!empty($email)){
+                    Subscribers::add($email);
+                    $isSubscribe = true;
                 }
-            }           
+            }
+
+            if (!empty($newCustomer->data)){
+                $listId = Settings::get('default_list');
+                $mappedFields = Map::get();
+                $details = current($newCustomer->data);
+
+                $autoSubscribe = Helper::getOption('automatic_subscription');
+                if (!empty($autoSubscribe) && $autoSubscribe ){
+                    if (!empty($email)){
+                        Subscribers::add($email);
+                    }
+                }
+
+                if (!empty($email) || isset($address['email'])){
+                    if (isset($address['email']) && !empty($address['email'])){
+                        $emailToEnroll = $address['email'];
+                    } else if (!empty($email)){
+                        $emailToEnroll = $email;
+                    }
+
+                    $alreadyEnroll = Subscribers::get($emailToEnroll);
+                    if (!empty($alreadyEnroll)){
+                        $isSubscribe = true;
+                    }
+                }
+
+                $expiry = Settings::get('expiry');
+                $auth = array(
+                    'access_token' => Settings::get('access_token'),
+                    'refresh_token' => Settings::get('refresh_token')
+                );
+                if ($expiry !== null && ($expiry - time() <  (60*60*24)))
+                {
+                    list($new_access_token, $new_expires_in, $new_refresh_token) = self::$CampaignMonitor->refresh_token($auth);
+
+                    Settings::add('access_token',$new_access_token);
+                    Settings::add('refresh_token',$new_refresh_token);
+                    Settings::add('expiry',$new_expires_in + time());
+                    $auth = array(
+                        'access_token' => $new_access_token,
+                        'refresh_token' => $new_refresh_token
+                    );
+                }
+
+                $userToExport = Customer::format($details, $mappedFields, $isSubscribe);
+                $userToExport = (array)$userToExport;
+                $result = self::$CampaignMonitor->add_subscriber($listId, $userToExport, $auth);
+                Log::write($result);
+
+            }
         }
     }
     public static function woocommerce_subscription_box(){

--- a/core/App.php
+++ b/core/App.php
@@ -404,10 +404,7 @@ class App
                 if ($type == 'create_list') {
                     $clientId = $data['client_id'];
                     $listName = $data['list_name'];
-                    $optIn = $data['opt_in'];
-                    $optIn = ($optIn == 2) ? true : false;
-                    $newList = App::$CampaignMonitor->create_list($clientId, $listName, $optIn);
-
+                    $newList = App::$CampaignMonitor->create_list($clientId, $listName, false);
 
                     Settings::add('default_list', $newList);
                     Settings::add('default_client',$clientId );

--- a/readme.txt
+++ b/readme.txt
@@ -11,7 +11,7 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Easily subscribe customers to your Campaign Monitor mailing list at checkout.
 
 == Description ==
-Campaign Monitor for WooCommerce allows your customers to sign up to a list in your [campaignmonitor.com](https://www.campaignmonitor.com?utm_source=woocommerce-plugin&utm_medium=referral) account at checkout. You can then use your list to send campaigns or automated journeys.
+Campaign Monitor for WooCommerce allows your customers to be added to a list in your [campaignmonitor.com](https://www.campaignmonitor.com?utm_source=woocommerce-plugin&utm_medium=referral) account at checkout.
 
 Get started with pre-packaged segments. Once connected with your Campaign Monitor account, you’ll automatically be set up with segments, which help you target smaller groups of subscribers:
 
@@ -35,7 +35,21 @@ Campaign Monitor makes it radically easy to create, send and measure the impact 
 PHP 7 introduced connectivity issues between our plugin and Campaign Monitor when the WordPress site is not running on HTTPS. We are unable to resolve this problem with a regular update from your Admin. If you are experiencing this problem, you will need to disconnect, delete the plugin and install the latest version. We apologize for the inconvenience.
 
 == Frequently Asked Questions ==
+= Why am I unable to use the Confirmed opt-in list for this plugin?
+- If the list has the "Confirmed opt-in" setting enabled, new customers (determined by their email address) will be sent a confirmation email with a link to validate their email address before being added to the list. This would happen even if they did not select the subscription option at checkout. To prevent this from happening, we had disable selecting Confirmed opt-in list to be used for this plugin.
 
+= Would my list still be clean if I am using Single opt-in list?
+- Given that the email address is used in the checkout process, it is most likely that valid email address is being used and therefore your list should still be clean.
+
+= Who is subscribed to my list with this plugin? =
+- Customers that have been through the checkout process in your WooCommerce store are added to the list that you have configured. This enables basic analytics to be calculated around high-spender / repeat customers.  
+- If you have enabled the setting "Show subscription option at checkout" AND the customer chooses to opt-in to this at checkout, the customer would also be added to the "WooCommerce Newsletter Subscribers" segment in your list. 
+
+= Does this plugin send an email to my customers?
+- This plugin does not send any emails. You would need to either send an email manually or have email automation set up in the Campaign Monitor platform. 
+
+= Do I need a Campaign Monitor account to use this plugin? =
+Yes, you do ([sign up here](https://www.campaignmonitor.com/?utm_source=woocommerce-plugin&utm_medium=referral)).
 
 == Screenshots ==
 
@@ -44,8 +58,6 @@ PHP 7 introduced connectivity issues between our plugin and Campaign Monitor whe
 
 == Changelog ==
 
-= 1.5.0 =
-* Major change as the subscribers are added only when they choose to subscribe to newsletter (ie: added to the list and newsletter-segments, where previously it was added to the list and only added to the newsletter-segment when they choose to subscribe to newsletter).
 = 1.4.9 =
 = 1.4.8 =
 * Minor fixes for PHP8

--- a/readme.txt
+++ b/readme.txt
@@ -58,6 +58,10 @@ Yes, you do ([sign up here](https://www.campaignmonitor.com/?utm_source=woocomme
 
 == Changelog ==
 
+= 1.5.0 =
+* Change to disable the use of Confirmed opt-in List for this plugin. 
+* Updated to add FAQ to explain why Confirmed opt-in List is not suitable for this plugin.
+* Also when creating a new list, remove the ability to select the list type (Single opt-in or Confirmed opt-in). This would now always default to Single opt-in.
 = 1.4.9 =
 = 1.4.8 =
 * Minor fixes for PHP8

--- a/readme.txt
+++ b/readme.txt
@@ -59,8 +59,8 @@ Yes, you do ([sign up here](https://www.campaignmonitor.com/?utm_source=woocomme
 == Changelog ==
 
 = 1.5.0 =
-* Change to disable the use of Confirmed opt-in List for this plugin. 
-* Updated to add FAQ to explain why Confirmed opt-in List is not suitable for this plugin.
+* Change to disable the use of Confirmed opt-in List for this plugin. Please check your setting that you have the correct list type.
+* Added FAQ to explain why Confirmed opt-in List is not suitable for this plugin.
 * Also when creating a new list, remove the ability to select the list type (Single opt-in or Confirmed opt-in). This would now always default to Single opt-in.
 = 1.4.9 =
 = 1.4.8 =

--- a/views/admin/connect.php
+++ b/views/admin/connect.php
@@ -115,6 +115,7 @@ if (!empty($appSettings) && !empty($accessToken)) {
 $clientListSettings = \core\ClientList::get($defaultList);
 
 $actionUrl = get_admin_url() . 'admin.php?page=campaign_monitor_woocommerce';
+$isConfirmedOptInList = false;
 
 if (!empty($defaultList)) {
     $getOnlyVisibleFields = true;
@@ -132,7 +133,9 @@ if (!empty($defaultList)) {
     if (empty($currentList)) {
         \core\Settings::add('default_list', null);
         echo "<script>location.reload();</script>";
-
+    }
+    else {
+        $isConfirmedOptInList = $currentList->ConfirmedOptIn;
     }
 
 }
@@ -269,8 +272,12 @@ $subscriptionBox = \core\Helper::getOption('toggle_subscription_box');
             </p>
         </div>
     <?php endif; ?>
-
-
+    
+    <?php if ((is_array($notices) && !in_array('confirmed_opt_in_notice',$notices, TRUE ) ) && $isConfirmedOptInList) : ?>
+        <div data-method="confirmed_opt_in_notice" class="updated notice cm-plugin-ad is-dismissible">
+            <p>Your previous setting is using a confirmed-opt-in list which is not suitable for this plugin. Please select a single-opt-in list and save your changes.</p>
+        </div>
+    <?php endif; ?>
 
     <?php if (is_array($notices) &&!in_array('show_ad',$notices, TRUE )) : ?>
         <div id="cmPlugin" data-method="show_ad" class="updated notice cm-plugin-ad is-dismissible">

--- a/views/admin/connect.php
+++ b/views/admin/connect.php
@@ -339,7 +339,7 @@ $subscriptionBox = \core\Helper::getOption('toggle_subscription_box');
                                             <input type="hidden" name="data[app_nonce]" value="<?php echo wp_create_nonce( 'app_nonce' ); ?>">
                                             <input type="hidden" id="clientNameData" name="data[client_name]" placeholder="New Client Name" value="">
 
-                                            <button id="btnCreateNewClient" type="submit" class="regular-text ltr" placeholder="List Name">
+                                            <button id="btnCreateNewClient" type="submit" class="regular-text ltr">
                                                 Create Client
                                             </button>
                                         </form>
@@ -370,34 +370,15 @@ $subscriptionBox = \core\Helper::getOption('toggle_subscription_box');
                                 </tr>
                                 <tr valign="top" class="new-list-creation">
                                     <th scope="row">
-                                        List Type
+
                                     </th>
                                     <td>
-                                        <select id="listType" name="type" class="dropdown-select">
-                                            <option value="2" selected>Confirmed opt-in (confirmation required)</option>
-                                            <option value="1" >Single opt-in (no confirmation required)</option>
-                                        </select>
-                                        <p><em>
-                                                <strong>Single opt-in</strong> means new subscribers are added to this list as soon as
-                                                they complete the subscribe form.
-                                            </em>
-                                        </p>
-                                        <p><em>
-                                                <strong>Confirmed opt-in</strong> means a confirmation email will be sent with a link they must click to validate their address. This confirmation isn't required when you
-                                                import existing subscribers, only when new subscribers join via your subscribe form.</em></p>
-                                        <p><em><a href="http://help.campaignmonitor.com/topic.aspx?t=16">Learn more about confirmed opt-in lists.</a></em> </p>
-
-
                                         <form action="<?php echo get_admin_url(); ?>admin-post.php" method="post">
                                             <input type="hidden" name="action" value="handle_request">
                                             <input type="hidden" name="data[type]" value="create_list">
                                             <input type="hidden" name="data[app_nonce]" value="<?php echo wp_create_nonce( 'app_nonce' ); ?>">
                                             <input type="hidden" id="listNameData" name="data[list_name]" value="">
                                             <input type="hidden" id="clientIdData" name="data[client_id]" value="">
-                                            <input type="hidden" id="optInData" name="data[opt_in]" value="">
-                                            <!--                                            <button id="btnCreateList" type="submit" class="regular-text ltr" placeholder="List Name">-->
-                                            <!--                                                Create List-->
-                                            <!--                                            </button>-->
                                         </form>
                                     </td>
                                 </tr>
@@ -406,7 +387,6 @@ $subscriptionBox = \core\Helper::getOption('toggle_subscription_box');
                                         Subscription Box
                                     </th>
                                     <td>
-
                                         <label for="subscriptionBox">
                                             <input id="subscriptionBox" name="toggle_subscription_box"  checked="checked" <?php echo (isset($clientListSettings['toggle_subscription_box']) && $clientListSettings['toggle_subscription_box']) ? 'checked="checked"': ''; ?>  type="checkbox">  Show subscription option at checkout</label>
 

--- a/views/admin/js/ajax.js
+++ b/views/admin/js/ajax.js
@@ -26,6 +26,14 @@ jQuery(document).ready(function($) {
         e.preventDefault();
 
         var params = $("#lists option:selected").attr('data-url');
+        
+        if (!params){
+            e.preventDefault();
+            $('#lists').css("border", "1px solid red");
+            return false;
+        } else {
+            $('#lists').css("border", "1px solid #8c8f94");
+        }
 
         var dataToSend = JSON.parse('{"' + decodeURI(params).replace(/"/g, '\\"').replace(/&/g, '","').replace(/=/g,'":"') + '"}');
 

--- a/views/admin/js/ajax.js
+++ b/views/admin/js/ajax.js
@@ -45,15 +45,12 @@ jQuery(document).ready(function($) {
         var subscriptionBox =  $('#subscriptionBox').is(':checked');
 
         var listToCreate = newList.val();
-        var listType = $('#listType').val();
         
         dataToSend.debug = debug;
         dataToSend.subscribe = subscribe;
         dataToSend.subscribe_text = subscribeText;
         dataToSend.subscriptionBox = subscriptionBox;
         dataToSend.new_list_name = listToCreate;
-        dataToSend.new_list_type = listType;
-
 
         $.ajax({
             type: "POST",

--- a/views/admin/js/app.js
+++ b/views/admin/js/app.js
@@ -117,9 +117,6 @@ jQuery(document).ready(function($) {
     $(document).on('click', '#btnCreateList', function (e) {
         var name = $('#listName').val();
         var id = $('#clientSelection').val();
-        var optIn = $('#listType').val();
-
-
 
         if ( name == ''){
             $('#listName').css('border', '1px solid #FF0000');
@@ -129,7 +126,6 @@ jQuery(document).ready(function($) {
             $('.campaign-monitor-woocommerce .progress-notice').slideDown();
             $('#listNameData').val(name);
             $('#clientIdData').val(id);
-            $('#optInData').val(optIn);
         }
     });
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/41770203/198882774-b2ef0428-124d-44cc-becc-5dffd53a36fa.png)
The lists are now split into 2 sections, where the confirmed opt-in lists are not selectable.
NB: Caveat is that if someone had used single opt-in initially, but then updated to use confirmed opt-in. 

Before: 
![image](https://user-images.githubusercontent.com/41770203/198882898-91f3e11a-5eca-42ec-9677-72b413bfa8a0.png)

After:
![image](https://user-images.githubusercontent.com/41770203/198882826-e457dd83-40fe-4470-bbc6-179fd30bfc02.png)
